### PR TITLE
リンク先訂正

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -6,7 +6,7 @@
       - @group.users.each do |user|
         =user.name
     .main_chat__btn-box
-      =link_to edit_group_path(current_user), class: "main_chat__edit" do
+      =link_to edit_group_path(@group.id), class: "main_chat__edit" do
         Edit
 
   .main_chat__message-list


### PR DESCRIPTION
# What
 Editリンク先表示の訂正

# Why
 id1しか表示されなかったため、その都度変更に応じたidナンバーを表示させるため。